### PR TITLE
Feat(#15)컵케이크 엔티티 및 api 생성

### DIFF
--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/CupCakeController.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/CupCakeController.java
@@ -1,0 +1,58 @@
+package com.example.test.omnivore2trendithon2025.cupcake.api;
+
+import com.example.test.omnivore2trendithon2025.cupcake.api.dto.request.CupCakeYearMonthRequest;
+import com.example.test.omnivore2trendithon2025.cupcake.api.dto.request.SaveCupCakeRequest;
+import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.CupCakeResponse;
+import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.SaveCupCakeResponse;
+import com.example.test.omnivore2trendithon2025.cupcake.application.CupCakeService;
+import com.example.test.omnivore2trendithon2025.global.annotation.CurrentUserEmail;
+import com.example.test.omnivore2trendithon2025.global.template.RspTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cupcakes")
+public class CupCakeController {
+
+    private final CupCakeService cupCakeService;
+
+    @PostMapping
+    public RspTemplate<SaveCupCakeResponse> createCupCake(
+            @CurrentUserEmail String email,
+            @RequestBody SaveCupCakeRequest request) {
+
+        return new RspTemplate<>(
+            HttpStatus.CREATED,
+            "컵케이크 생성 완료!",
+            cupCakeService.saveCupCake(email, request));
+    }
+
+    @GetMapping("/{cupCakeId}")
+    public RspTemplate<CupCakeResponse> findCupCake(
+            @CurrentUserEmail String email,
+            @PathVariable Long cupCakeId) {
+
+        return new RspTemplate<>(
+                HttpStatus.OK,
+                "컵케이크 조회 완료!",
+                cupCakeService.findCupCake(email, cupCakeId)
+        );
+    }
+
+    @GetMapping("/date")
+    public RspTemplate<List<CupCakeResponse>> findMyCupCakes(
+            @CurrentUserEmail String email,
+            @RequestBody CupCakeYearMonthRequest request
+            ){
+
+        return new RspTemplate<>(
+                HttpStatus.OK,
+                "연도와 월에 맞는 컵케이크들 조회 완료!",
+                cupCakeService.findMyCupCakes(email, request.yearMonth())
+        );
+    }
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/CupCakeDocs.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/CupCakeDocs.java
@@ -1,0 +1,4 @@
+package com.example.test.omnivore2trendithon2025.cupcake.api;
+
+public interface CupCakeDocs {
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/request/CupCakeYearMonthRequest.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/request/CupCakeYearMonthRequest.java
@@ -1,0 +1,8 @@
+package com.example.test.omnivore2trendithon2025.cupcake.api.dto.request;
+
+import java.time.YearMonth;
+
+public record CupCakeYearMonthRequest(
+        YearMonth yearMonth
+) {
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/request/SaveCupCakeRequest.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/request/SaveCupCakeRequest.java
@@ -1,0 +1,11 @@
+package com.example.test.omnivore2trendithon2025.cupcake.api.dto.request;
+
+import com.example.test.omnivore2trendithon2025.cupcake.domain.AccessRange;
+import com.example.test.omnivore2trendithon2025.cupcake.domain.Emotion;
+
+public record SaveCupCakeRequest(
+        Emotion emotion,
+        String content,
+        AccessRange accessRange
+) {
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/CupCakeResponse.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/CupCakeResponse.java
@@ -9,11 +9,13 @@ import java.time.LocalDateTime;
 
 @Builder
 public record CupCakeResponse(
+        Long cupCakeId,
         Emotion emotion,
         String content,
         LocalDateTime date,
         AccessRange accessRange,
         Integer likeCount
+        //boolean like
 ) {
     public static CupCakeResponse of(Emotion emotion, String content, LocalDateTime date, AccessRange accessRange, Integer likeCount) {
         return CupCakeResponse.builder()

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/CupCakeResponse.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/CupCakeResponse.java
@@ -1,0 +1,27 @@
+package com.example.test.omnivore2trendithon2025.cupcake.api.dto.response;
+
+import com.example.test.omnivore2trendithon2025.cupcake.domain.AccessRange;
+import com.example.test.omnivore2trendithon2025.cupcake.domain.CupCake;
+import com.example.test.omnivore2trendithon2025.cupcake.domain.Emotion;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record CupCakeResponse(
+        Emotion emotion,
+        String content,
+        LocalDateTime date,
+        AccessRange accessRange,
+        Integer likeCount
+) {
+    public static CupCakeResponse of(Emotion emotion, String content, LocalDateTime date, AccessRange accessRange, Integer likeCount) {
+        return CupCakeResponse.builder()
+                .emotion(emotion)
+                .content(content)
+                .date(date)
+                .accessRange(accessRange)
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/SaveCupCakeResponse.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/SaveCupCakeResponse.java
@@ -1,0 +1,9 @@
+package com.example.test.omnivore2trendithon2025.cupcake.api.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SaveCupCakeResponse(
+    Long cupCakeId
+) {
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/application/CupCakeService.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/application/CupCakeService.java
@@ -1,0 +1,93 @@
+package com.example.test.omnivore2trendithon2025.cupcake.application;
+
+import com.example.test.omnivore2trendithon2025.cupcake.api.dto.request.SaveCupCakeRequest;
+import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.CupCakeResponse;
+import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.SaveCupCakeResponse;
+import com.example.test.omnivore2trendithon2025.cupcake.domain.AccessRange;
+import com.example.test.omnivore2trendithon2025.cupcake.domain.CupCake;
+import com.example.test.omnivore2trendithon2025.cupcake.domain.repository.CupCakeRepository;
+import com.example.test.omnivore2trendithon2025.cupcake.exception.CupCakeNotFoundException;
+import com.example.test.omnivore2trendithon2025.cupcake.exception.LowCupCakeAccessRoleException;
+import com.example.test.omnivore2trendithon2025.member.domain.Member;
+import com.example.test.omnivore2trendithon2025.member.domain.repository.MemberRepository;
+import com.example.test.omnivore2trendithon2025.member.exception.MemberNotFoundException;
+import com.example.test.omnivore2trendithon2025.member.follow.domain.repository.FollowRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CupCakeService {
+
+    private final CupCakeRepository cupCakeRepository;
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    @Transactional
+    public SaveCupCakeResponse saveCupCake(String email, SaveCupCakeRequest dto) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+
+        CupCake newCupCake = CupCake.createCupCake(member, dto.emotion(), dto.content(), dto.accessRange());
+
+        cupCakeRepository.save(newCupCake);
+
+        return SaveCupCakeResponse.builder()
+                .cupCakeId(newCupCake.getId())
+                .build();
+    }
+
+    public CupCakeResponse findCupCake(String email, Long cupCakeId) {
+        CupCake target = cupCakeRepository.findById(cupCakeId)
+                .orElseThrow(CupCakeNotFoundException::new);
+
+        // 내 컵케이크: 즉시 조회
+        if(isMine(email, target.getMember().getEmail())) return CupCakeToResponse(target);
+
+        // 내 컵케이크 x: 조건 확인 후 처리
+        return switch (target.getAccessRange()) {
+            case PUBLIC -> CupCakeToResponse(target);
+            case FRIEND -> {
+                if (existsFollow(email, target.getMember().getEmail()))
+                    yield CupCakeToResponse(target);
+                throw new LowCupCakeAccessRoleException();
+            }
+            default -> throw new LowCupCakeAccessRoleException();
+        };
+
+    }
+    
+    public List<CupCakeResponse> findMyCupCakes(String email, YearMonth yearMonth) {
+
+    }
+
+    public List<CupCakeResponse> findByAccessRangeAndEmail(AccessRange accessRange, String email) {
+
+    }
+
+    private CupCakeResponse CupCakeToResponse(CupCake target) {
+        return CupCakeResponse.of(target.getEmotion(),
+                    target.getContent(),
+                    target.getCreatedAt(),
+                    target.getAccessRange(),
+                    target.getLikeCount());
+    }
+
+    private boolean isMine(String email, String targetEmail) {
+        return email.equals(targetEmail);
+    }
+
+    private boolean existsFollow(String clientEmail, String targetEmail) {
+        return followRepository.existsByFromMemberAndToMember(
+                memberRepository.findByEmail(clientEmail)
+                        .orElseThrow(MemberNotFoundException::new),
+                memberRepository.findByEmail(targetEmail)
+                        .orElseThrow(MemberNotFoundException::new)
+        );
+    }
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/application/CupCakeService.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/application/CupCakeService.java
@@ -61,13 +61,13 @@ public class CupCakeService {
         };
 
     }
-    
-    public List<CupCakeResponse> findMyCupCakes(String email, YearMonth yearMonth) {
 
+    public List<CupCakeResponse> findMyCupCakes(String email, YearMonth yearMonth) {
+        return cupCakeRepository.findByMemberAndYearMonth(email, yearMonth.getYear(), yearMonth.getMonthValue());
     }
 
     public List<CupCakeResponse> findByAccessRangeAndEmail(AccessRange accessRange, String email) {
-
+        return List.of();
     }
 
     private CupCakeResponse CupCakeToResponse(CupCake target) {

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/AccessRange.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/AccessRange.java
@@ -1,0 +1,5 @@
+package com.example.test.omnivore2trendithon2025.cupcake.domain;
+
+public enum AccessRange {
+    PUBLIC, FRIEND, PRIVATE
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/CupCake.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/CupCake.java
@@ -3,10 +3,13 @@ package com.example.test.omnivore2trendithon2025.cupcake.domain;
 import com.example.test.omnivore2trendithon2025.global.entity.BaseEntity;
 import com.example.test.omnivore2trendithon2025.member.domain.Member;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CupCake extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -30,5 +33,16 @@ public class CupCake extends BaseEntity {
 
     public void decreaseLikeCount() {
         this.likeCount--;
+    }
+
+    public static CupCake createCupCake(Member member, Emotion emotion, String content, AccessRange accessRange) {
+        CupCake cupCake = new CupCake();
+        cupCake.member = member;
+        cupCake.emotion = emotion;
+        cupCake.content = content;
+        cupCake.accessRange = accessRange;
+        cupCake.likeCount = 0;
+
+        return cupCake;
     }
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/CupCake.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/CupCake.java
@@ -1,0 +1,34 @@
+package com.example.test.omnivore2trendithon2025.cupcake.domain;
+
+import com.example.test.omnivore2trendithon2025.global.entity.BaseEntity;
+import com.example.test.omnivore2trendithon2025.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class CupCake extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private Integer likeCount;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private AccessRange accessRange;
+
+    @Enumerated(EnumType.STRING)
+    private Emotion emotion;
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount--;
+    }
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/CupCake.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/CupCake.java
@@ -4,12 +4,16 @@ import com.example.test.omnivore2trendithon2025.global.entity.BaseEntity;
 import com.example.test.omnivore2trendithon2025.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class CupCake extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/Emotion.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/Emotion.java
@@ -1,0 +1,5 @@
+package com.example.test.omnivore2trendithon2025.cupcake.domain;
+
+public enum Emotion {
+    HAPPY, SO_SO, SAD, NERVOUS, ANGRY;
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeRepository.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeRepository.java
@@ -1,11 +1,21 @@
 package com.example.test.omnivore2trendithon2025.cupcake.domain.repository;
 
-import com.example.test.omnivore2trendithon2025.cupcake.domain.AccessRange;
+import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.CupCakeResponse;
 import com.example.test.omnivore2trendithon2025.cupcake.domain.CupCake;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface CupCakeRepository extends JpaRepository<CupCake, Long> {
-    List<CupCake> findByAccessRangeAndMember_Email(AccessRange range, String email);
+public interface CupCakeRepository extends JpaRepository<CupCake, Long>{
+    @Query("SELECT new com.example.test.omnivore2trendithon2025.cupcake" +
+            ".api.dto.response.CupCakeResponse(" +
+            "c.id, c.emotion, c.content, c.createdAt, c.accessRange, c.likeCount) FROM CupCake c " +
+            "WHERE c.member.email = :email " +
+            "AND FUNCTION('YEAR', c.createdAt) = :year " +
+            "AND FUNCTION('MONTH', c.createdAt) = :month")
+    List<CupCakeResponse> findByMemberAndYearMonth(@Param("email") String email,
+                                                   @Param("year") int year,
+                                                   @Param("month") int month);
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeRepository.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeRepository.java
@@ -1,0 +1,11 @@
+package com.example.test.omnivore2trendithon2025.cupcake.domain.repository;
+
+import com.example.test.omnivore2trendithon2025.cupcake.domain.AccessRange;
+import com.example.test.omnivore2trendithon2025.cupcake.domain.CupCake;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CupCakeRepository extends JpaRepository<CupCake, Long> {
+    List<CupCake> findByAccessRangeAndMember_Email(AccessRange range, String email);
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/exception/CupCakeNotFoundException.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/exception/CupCakeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.test.omnivore2trendithon2025.cupcake.exception;
+
+import com.example.test.omnivore2trendithon2025.global.error.exception.NotFoundGroupException;
+
+public class CupCakeNotFoundException extends NotFoundGroupException {
+    public CupCakeNotFoundException(String message) {
+        super(message);
+    }
+    public CupCakeNotFoundException() { this("컵케이크를 찾을 수 없습니다."); }
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/exception/LowCupCakeAccessRoleException.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/exception/LowCupCakeAccessRoleException.java
@@ -1,0 +1,10 @@
+package com.example.test.omnivore2trendithon2025.cupcake.exception;
+
+import com.example.test.omnivore2trendithon2025.global.error.exception.AccessDeniedGroupException;
+
+public class LowCupCakeAccessRoleException extends AccessDeniedGroupException {
+    public LowCupCakeAccessRoleException(String message) {
+        super(message);
+    }
+    public LowCupCakeAccessRoleException() { this("친구가 아니거나, 비공개 컵케이크 입니다."); }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #15 컵케이크 엔티티 및 api 작업

### 📝작업 내용

> 컵케이크 엔티티와 api를 생성했습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d225c1a1-ea7c-4b7f-b5bc-1b6a5c0a15eb)
QueryDsl 기반으로 처리하려 했으나, QCupCake 클래스가 컵케이크 엔티티가 가지는 열거형이나, 필드들을 가지지 못함.

그래서 우선 급하게 임시로 JPQL로 짜놓았습니다..

추가로, 15번 브랜치에 좋아요 엔티티 관련 코드가 존재하지 않아 먼저 머지하고, 이슈 추가하여 새 브랜치로 작업 진행할 예정입니다.

