### PR TITLE
컵케이크 조회 제공 데이터 수정 및 컵케이크 생성 예외 로직 추가

### DIFF
--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/CupCakeYearMonthResponse.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/CupCakeYearMonthResponse.java
@@ -9,6 +9,9 @@ import java.time.LocalDateTime;
 public record CupCakeYearMonthResponse(
         Long cupCakeId,
         Emotion emotion,
-        LocalDateTime date
+        LocalDateTime date,
+        String content,
+        Integer likeCount,
+        boolean like
 ) {
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/FollowCupCakeResponse.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/api/dto/response/FollowCupCakeResponse.java
@@ -13,6 +13,7 @@ public record FollowCupCakeResponse(
         LocalDateTime date,
         AccessRange accessRange,
         Emotion emotion,
+        String content,
         Integer likeCount,
         boolean like
 ) {
@@ -22,6 +23,7 @@ public record FollowCupCakeResponse(
             LocalDateTime date,
             AccessRange accessRange,
             Emotion emotion,
+            String content,
             Integer likeCount,
             boolean like) {
 
@@ -31,6 +33,7 @@ public record FollowCupCakeResponse(
                 .date(date)
                 .accessRange(accessRange)
                 .emotion(emotion)
+                .content(content)
                 .likeCount(likeCount)
                 .like(like)
                 .build();

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/application/CupCakeService.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/application/CupCakeService.java
@@ -6,6 +6,7 @@ import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.*;
 import com.example.test.omnivore2trendithon2025.cupcake.domain.AccessRange;
 import com.example.test.omnivore2trendithon2025.cupcake.domain.CupCake;
 import com.example.test.omnivore2trendithon2025.cupcake.domain.repository.CupCakeRepository;
+import com.example.test.omnivore2trendithon2025.cupcake.exception.AlreadyExistThisDateException;
 import com.example.test.omnivore2trendithon2025.cupcake.exception.CupCakeNotFoundException;
 import com.example.test.omnivore2trendithon2025.cupcake.exception.LowCupCakeAccessRoleException;
 import com.example.test.omnivore2trendithon2025.heart.domain.repository.HeartRepository;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 
@@ -36,6 +38,9 @@ public class CupCakeService {
     public SaveCupCakeResponse saveCupCake(String email, SaveCupCakeRequest dto) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(MemberNotFoundException::new);
+
+        if(cupCakeRepository.isExistByLocalDate(LocalDate.now()))
+            throw new AlreadyExistThisDateException();
 
         CupCake newCupCake = CupCake.createCupCake(member, dto.emotion(), dto.content(), dto.accessRange());
 

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/application/CupCakeService.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/application/CupCakeService.java
@@ -39,7 +39,7 @@ public class CupCakeService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(MemberNotFoundException::new);
 
-        if(cupCakeRepository.isExistByLocalDate(LocalDate.now()))
+        if(cupCakeRepository.isExistByLocalDate(member, LocalDate.now()))
             throw new AlreadyExistThisDateException();
 
         CupCake newCupCake = CupCake.createCupCake(member, dto.emotion(), dto.content(), dto.accessRange());

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepository.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepository.java
@@ -5,6 +5,7 @@ import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.CupCake
 import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.FollowCupCakeResponse;
 import com.example.test.omnivore2trendithon2025.cupcake.domain.AccessRange;
 import com.example.test.omnivore2trendithon2025.cupcake.domain.CupCake;
+import com.example.test.omnivore2trendithon2025.member.domain.Member;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,5 +19,5 @@ public interface CupCakeCustomRepository {
 
     List<CupCake> findByEmail(String email);
 
-    boolean isExistByLocalDate(LocalDate date);
+    boolean isExistByLocalDate(Member member, LocalDate date);
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepository.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepository.java
@@ -6,6 +6,7 @@ import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.FollowC
 import com.example.test.omnivore2trendithon2025.cupcake.domain.AccessRange;
 import com.example.test.omnivore2trendithon2025.cupcake.domain.CupCake;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface CupCakeCustomRepository {
@@ -16,4 +17,6 @@ public interface CupCakeCustomRepository {
     List<FollowCupCakeResponse> findByFollowerIds(Long memberId, List<Long> followerIds);
 
     List<CupCake> findByEmail(String email);
+
+    boolean isExistByLocalDate(LocalDate date);
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepositoryImpl.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.CupCake
 import com.example.test.omnivore2trendithon2025.cupcake.api.dto.response.FollowCupCakeResponse;
 import com.example.test.omnivore2trendithon2025.cupcake.domain.AccessRange;
 import com.example.test.omnivore2trendithon2025.cupcake.domain.CupCake;
+import com.example.test.omnivore2trendithon2025.member.domain.Member;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
@@ -120,10 +121,11 @@ public class CupCakeCustomRepositoryImpl implements CupCakeCustomRepository {
     }
 
     @Override
-    public boolean isExistByLocalDate(LocalDate date) {
+    public boolean isExistByLocalDate(Member member, LocalDate date) {
         return queryFactory.
                 selectFrom(cupCake)
-                .where(cupCake.createdAt.year().eq(date.getYear())
+                .where(cupCake.member.eq(member)
+                        .and(cupCake.createdAt.year().eq(date.getYear()))
                         .and(cupCake.createdAt.month().eq(date.getMonthValue()))
                         .and(cupCake.createdAt.dayOfMonth().eq(date.getDayOfMonth())))
                 .fetchFirst() != null;

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepositoryImpl.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepositoryImpl.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -116,5 +117,15 @@ public class CupCakeCustomRepositoryImpl implements CupCakeCustomRepository {
                 .join(cupCake.member, member)
                 .where(member.email.eq(email))
                 .fetch();
+    }
+
+    @Override
+    public boolean isExistByLocalDate(LocalDate date) {
+        return queryFactory.
+                selectFrom(cupCake)
+                .where(cupCake.createdAt.year().eq(date.getYear())
+                        .and(cupCake.createdAt.month().eq(date.getMonthValue()))
+                        .and(cupCake.createdAt.dayOfMonth().eq(date.getDayOfMonth())))
+                .fetchFirst() != null;
     }
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepositoryImpl.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepositoryImpl.java
@@ -35,7 +35,20 @@ public class CupCakeCustomRepositoryImpl implements CupCakeCustomRepository {
                 .select(Projections.constructor(CupCakeYearMonthResponse.class,
                         cupCake.id,
                         cupCake.emotion,
-                        cupCake.createdAt))
+                        cupCake.createdAt,
+                        cupCake.content,
+                        cupCake.likeCount,
+                        ExpressionUtils.as(
+                                JPAExpressions
+                                        .select()
+                                        .from(heart)
+                                        .where(
+                                                heart.member.email.eq(email),
+                                                heart.cupCake.member.email.eq(email)
+                                        )
+                                        .exists(),
+                                "like"
+                        )))
                 .from(cupCake)
                 .where(
                         cupCake.member.email.eq(email),
@@ -77,6 +90,7 @@ public class CupCakeCustomRepositoryImpl implements CupCakeCustomRepository {
                         cupCake.createdAt,
                         cupCake.accessRange,
                         cupCake.emotion,
+                        cupCake.content,
                         cupCake.likeCount,
                         ExpressionUtils.as(
                                 JPAExpressions

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/exception/AlreadyExistThisDateException.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/exception/AlreadyExistThisDateException.java
@@ -1,0 +1,10 @@
+package com.example.test.omnivore2trendithon2025.cupcake.exception;
+
+import com.example.test.omnivore2trendithon2025.global.error.exception.InvalidGroupException;
+
+public class AlreadyExistThisDateException extends InvalidGroupException {
+    public AlreadyExistThisDateException(String message) {
+        super(message);
+    }
+    public AlreadyExistThisDateException() { this("오늘자 컵케이크가 이미 생성되었습니다."); }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #30 컵케이크 조회 시 응답해주는 데이터 추가 및 컵케이크 생성 시 예외 로직 추가

### 📝작업 내용

> 컵케이크 동일한 날짜에 중복 생성을 막는 예외 처리 및 응답 데이터 추가

