### PR TITLE
Feat(#49): 좋아요 로직 관련 이슈 수정

### DIFF
--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/CakeApiController.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/CakeApiController.java
@@ -64,11 +64,13 @@ public class CakeApiController implements CakeDocs{
     }
 
     @GetMapping("/member/{memberId}")
-    public RspTemplate<MyCakeResponse> findByMemberId(@PathVariable Long memberId) {
+    public RspTemplate<OtherCakeResponse> findByMemberId(
+            @CurrentUserEmail String email,
+            @PathVariable Long memberId) {
         return new RspTemplate<>(
                 HttpStatus.OK,
                 "케이크 조회 완료!",
-                cakeService.findByMemberId(memberId)
+                cakeService.findByMemberId(email, memberId)
         );
     }
 

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/CakeApiController.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/CakeApiController.java
@@ -1,6 +1,7 @@
 package com.example.test.omnivore2trendithon2025.cake.api;
 
 import com.example.test.omnivore2trendithon2025.cake.api.dto.request.SurveyRequest;
+import com.example.test.omnivore2trendithon2025.cake.api.dto.response.GuestCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.MyCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.OtherCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.SurveyResponse;
@@ -84,4 +85,15 @@ public class CakeApiController implements CakeDocs{
                 "팔로워 케이크 조회 완료!",
                 cakeService.findFollowerCakes(email, PageRequest.of(page, size)));
     }
+
+    @GetMapping("/{memberId}")
+    public RspTemplate<GuestCakeResponse> shareCake(@PathVariable Long memberId) {
+        return new RspTemplate<>(
+                HttpStatus.OK,
+                "공유용 링크로 케이크 조회 완료!",
+                cakeService.findShareCake(memberId)
+        );
+    }
+
+
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/CakeDocs.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/CakeDocs.java
@@ -60,12 +60,13 @@ public interface CakeDocs {
     @Operation(summary = "케이크 사용자 id 기반 조회", description = "케이크 정보를 사용자 고유 id 기반으로 조회합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "케이크 조회 성공",
-                            content = @Content(schema = @Schema(implementation = MyCakeResponse.class))),
+                            content = @Content(schema = @Schema(implementation = OtherCakeResponse.class))),
                     @ApiResponse(responseCode = "400", description = "잘못된 요청"),
                     @ApiResponse(responseCode = "401", description = "인증 실패"),
                     @ApiResponse(responseCode = "500", description = "서버 오류")
             })
-    RspTemplate<MyCakeResponse> findByMemberId(
+    RspTemplate<OtherCakeResponse> findByMemberId(
+            @Parameter(description = "로그인한 유저의 이메일(토큰에서 자동 추출)", hidden = true) String email,
             @Parameter(description = "사용자 고유 ID", required = true) Long memberId);
 
 

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/CakeDocs.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/CakeDocs.java
@@ -1,10 +1,10 @@
 package com.example.test.omnivore2trendithon2025.cake.api;
 
 import com.example.test.omnivore2trendithon2025.cake.api.dto.request.SurveyRequest;
+import com.example.test.omnivore2trendithon2025.cake.api.dto.response.GuestCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.MyCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.OtherCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.SurveyResponse;
-import com.example.test.omnivore2trendithon2025.global.annotation.CurrentUserEmail;
 import com.example.test.omnivore2trendithon2025.global.template.RspTemplate;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -82,4 +81,17 @@ public interface CakeDocs {
             @Parameter(description = "로그인한 유저의 이메일(토큰에서 자동 추출)", hidden = true) String email,
             @Parameter(description = "페이지 번호", required = true) int page,
             @Parameter(description = "요청할 개수", required = true) int size);
+
+
+    @Operation(summary = "케이크 공유(링크 공유)", description = "사용자의 케이크를 조회합니다.(링크 공유용)",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "케이크 조회 성공",
+                            content = @Content(schema = @Schema(implementation = GuestCakeResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "500", description = "서버 오류")
+            })
+    RspTemplate<GuestCakeResponse> shareCake(
+            @Parameter(description = "사용자 고유 ID", required = true) Long memberId);
 }
+

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/dto/response/GuestCakeResponse.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/api/dto/response/GuestCakeResponse.java
@@ -1,0 +1,43 @@
+package com.example.test.omnivore2trendithon2025.cake.api.dto.response;
+
+import com.example.test.omnivore2trendithon2025.cake.domain.CakeColor;
+import com.example.test.omnivore2trendithon2025.cake.domain.cakecandle.api.dto.response.CakeCandleResponse;
+import com.example.test.omnivore2trendithon2025.cake.domain.cakecandle.domain.CakeCandle;
+import lombok.Builder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Builder
+public record GuestCakeResponse(
+        Long cakeId,
+        String nickname,
+        CakeColor color,
+        List<CakeCandleResponse> candles,
+        Integer likeCount
+) {
+    public static GuestCakeResponse of(Long cakeId, String nickname, CakeColor color,
+                                       List<CakeCandle> candles, Integer likeCount) {
+
+        return GuestCakeResponse.builder()
+                .cakeId(cakeId)
+                .nickname(nickname)
+                .color(color)
+                .candles(Optional.ofNullable(candles)
+                        .orElse(Collections.emptyList())
+                        .stream()
+                        .filter(Objects::nonNull)
+                        .map(candle -> CakeCandleResponse.builder()
+                                .candleId(candle.getId())
+                                .imgUrl(candle.getImgUrl())
+                                .content(candle.getContent())
+                                .candleIndex(candle.getCandleIndex())
+                                .build())
+                        .collect(Collectors.toList()))
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/application/CakeService.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/application/CakeService.java
@@ -1,6 +1,7 @@
 package com.example.test.omnivore2trendithon2025.cake.application;
 
 import com.example.test.omnivore2trendithon2025.cake.api.dto.request.SurveyRequest;
+import com.example.test.omnivore2trendithon2025.cake.api.dto.response.GuestCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.MyCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.OtherCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.domain.Cake;
@@ -96,4 +97,8 @@ public class CakeService {
         return cakeRepository.findFollowerCakes(member, followerIds);
     }
 
+    public GuestCakeResponse findShareCake(Long memberId) {
+         return cakeRepository.findByOnlyMemberId(memberId)
+                .orElseThrow(CakeNotFoundException::new);
+    }
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/application/CakeService.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/application/CakeService.java
@@ -75,14 +75,12 @@ public class CakeService {
                 cake.getLikeCount());
     }
 
-    public MyCakeResponse findByMemberId(Long memberId){
-        Cake cake = cakeRepository.findByMemberId(memberId)
-                .orElseThrow(CakeNotFoundException::new);
+    public OtherCakeResponse findByMemberId(String email, Long memberId){
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
 
-        return MyCakeResponse.of(cake.getId(),
-                cake.getColor(),
-                cake.getCandles(),
-                cake.getLikeCount());
+        return cakeRepository.findByMemberId(member, memberId)
+                .orElseThrow(CakeNotFoundException::new);
     }
 
     public List<OtherCakeResponse> findFollowerCakes(String email, Pageable pageable) {

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepository.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface CakeCustomRepository {
     Optional<Cake> findByMemberEmail(String email);
 
-    Optional<Cake> findByMemberId(Long memberId);
+    Optional<OtherCakeResponse> findByMemberId(Member member, Long memberId);
 
     List<OtherCakeResponse> findFollowerCakes(Member member, List<Long> followerIds);
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepository.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepository.java
@@ -1,5 +1,6 @@
 package com.example.test.omnivore2trendithon2025.cake.domain.repository;
 
+import com.example.test.omnivore2trendithon2025.cake.api.dto.response.GuestCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.OtherCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.domain.Cake;
 import com.example.test.omnivore2trendithon2025.member.domain.Member;
@@ -13,4 +14,6 @@ public interface CakeCustomRepository {
     Optional<OtherCakeResponse> findByMemberId(Member member, Long memberId);
 
     List<OtherCakeResponse> findFollowerCakes(Member member, List<Long> followerIds);
+
+    Optional<GuestCakeResponse> findByOnlyMemberId(Long memberId);
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepositoryImpl.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepositoryImpl.java
@@ -59,7 +59,7 @@ public class CakeCustomRepositoryImpl implements CakeCustomRepository {
                                                 .from(heart)
                                                 .where(
                                                         heart.member.eq(member),
-                                                        heart.cake.member.id.eq(memberId)
+                                                        heart.cake.eq(cake)
                                                 )
                                                 .exists(),
                                         "like"
@@ -89,7 +89,7 @@ public class CakeCustomRepositoryImpl implements CakeCustomRepository {
                                         .from(heart)
                                         .where(
                                                 heart.member.eq(member),
-                                                heart.cake.member.id.in(followerIds)
+                                                heart.cake.eq(cake)
                                         )
                                         .exists(),
                                 "like"

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepositoryImpl.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepositoryImpl.java
@@ -43,13 +43,31 @@ public class CakeCustomRepositoryImpl implements CakeCustomRepository {
     }
 
     @Override
-    public Optional<Cake> findByMemberId(Long memberId) {
+    public Optional<OtherCakeResponse> findByMemberId(Member member, Long memberId) {
 
-        return Optional.ofNullable(queryFactory
-                .selectFrom(cake)
-                .join(cake.member, member)
-                .where(member.id.eq(memberId))
-                .fetchOne());
+        return Optional.ofNullable(
+                queryFactory
+                        .select(Projections.constructor(OtherCakeResponse.class,
+                                cake.id,
+                                cake.member.nickname,
+                                cake.color,
+                                cake.candles,
+                                cake.likeCount,
+                                ExpressionUtils.as(
+                                        JPAExpressions
+                                                .selectOne()
+                                                .from(heart)
+                                                .where(
+                                                        heart.member.eq(member),
+                                                        heart.cake.member.id.eq(memberId)
+                                                )
+                                                .exists(),
+                                        "like"
+                                )
+                        ))
+                        .from(cake)
+                        .where(cake.member.id.eq(memberId))
+                        .fetchOne());
     }
 
     @Override

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepositoryImpl.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cake/domain/repository/CakeCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.example.test.omnivore2trendithon2025.cake.domain.repository;
 
+import com.example.test.omnivore2trendithon2025.cake.api.dto.response.GuestCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.api.dto.response.OtherCakeResponse;
 import com.example.test.omnivore2trendithon2025.cake.domain.Cake;
 import com.example.test.omnivore2trendithon2025.cake.domain.QCake;
@@ -98,5 +99,22 @@ public class CakeCustomRepositoryImpl implements CakeCustomRepository {
                 .from(cake)
                 .where(cake.member.id.in(followerIds))
                 .fetch();
+    }
+
+    @Override
+    public Optional<GuestCakeResponse> findByOnlyMemberId(Long memberId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .select(Projections.constructor(GuestCakeResponse.class,
+                                cake.id,
+                                cake.member.nickname,
+                                cake.color,
+                                cake.candles,
+                                cake.likeCount
+                        ))
+                        .from(cake)
+                        .where(cake.member.id.eq(memberId))
+                        .fetchOne()
+        );
     }
 }

--- a/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepositoryImpl.java
+++ b/src/main/java/com/example/test/omnivore2trendithon2025/cupcake/domain/repository/CupCakeCustomRepositoryImpl.java
@@ -46,7 +46,7 @@ public class CupCakeCustomRepositoryImpl implements CupCakeCustomRepository {
                                         .from(heart)
                                         .where(
                                                 heart.member.email.eq(email),
-                                                heart.cupCake.member.email.eq(email)
+                                                heart.cupCake.eq(cupCake)
                                         )
                                         .exists(),
                                 "like"
@@ -100,16 +100,17 @@ public class CupCakeCustomRepositoryImpl implements CupCakeCustomRepository {
                                         .from(heart)
                                         .where(
                                                 heart.member.id.eq(memberId),
-                                                heart.cupCake.member.id.in(followerIds)
+                                                heart.cupCake.eq(cupCake)
                                         )
                                         .exists(),
                                 "like"
                         )
                 ))
                 .from(cupCake)
-                .where(cupCake.member.id.in(followerIds)
-                        .and(cupCake.accessRange.eq(AccessRange.PUBLIC))
-                        .and(cupCake.accessRange.eq(AccessRange.FRIEND)))
+                .where(
+                        cupCake.member.id.in(followerIds)
+                                .and(cupCake.accessRange.in(AccessRange.PUBLIC, AccessRange.FRIEND))
+                )
                 .orderBy(cupCake.createdAt.desc())
                 .fetch();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #49 좋아요 로직 관련 조회 에러 이슈 파악 및 수정

### 📝작업 내용

> 팔로워 조회 간 데이터가 전달 되지 않는 문제 보완했고, 케이크 응답 데이터 추가 제공 및 공유용 api 하나 만들었습니다.


